### PR TITLE
feat: Support for Optional and Required Attributes with the use Property

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pack": "blerf build && blerf pack:publish",
     "deploy": "blerf build && blerf pack:deploy"
   },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "workspaces": [
     "packages/xmldom-decorators-cli",
     "packages/xmldom-decorators-test",

--- a/packages/sample-clients/package.json
+++ b/packages/sample-clients/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xinvoice/sample-clients",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Sample API clients generated using xmldom-decorators-cli",
   "author": "andersnm (forked by xinvoice)",
   "homepage": "https://github.com/xinvoice/xmldom-decorators#readme",

--- a/packages/xmldom-decorators-cli/package.json
+++ b/packages/xmldom-decorators-cli/package.json
@@ -18,14 +18,30 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "jest"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.11",
     "@types/node": "^10.12.7",
-    "typescript": "^3.3.1"
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.3.3"
   },
   "dependencies": {
     "@xinvoice/xmldom-decorators": "file:../xmldom-decorators"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.ts?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(ts?)$",
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "json",
+      "node"
+    ]
   },
   "blerf": {
     "steps": [

--- a/packages/xmldom-decorators-cli/package.json
+++ b/packages/xmldom-decorators-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xinvoice/xmldom-decorators-cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Command line tool to convert XSD to TypeScript classes using xmldom-decorators",
   "author": "andersnm (forked by xinvoice)",
   "license": "MIT",

--- a/packages/xmldom-decorators-cli/src/classformatter.ts
+++ b/packages/xmldom-decorators-cli/src/classformatter.ts
@@ -57,6 +57,10 @@ function formatDefault(m: SchemaMember): string {
         return "";
     }
 
+    if (m.use === "optional") {
+        return " = undefined";
+    }
+
     if (isArrayElement(m)) {
         return " = []";
     }
@@ -97,7 +101,7 @@ function isArrayElement(e: SchemaMember): boolean {
 }
 
 function formatOptional(m: SchemaMember): string {
-    if (m.minOccurs === 0) {
+    if (m.minOccurs === 0 || m.use === "optional") {
         return "?";
     }
 

--- a/packages/xmldom-decorators-cli/src/classtypes.ts
+++ b/packages/xmldom-decorators-cli/src/classtypes.ts
@@ -8,6 +8,7 @@ export interface SchemaMember {
     xmlType: 'attribute' | 'element' | 'array' | 'text';
     minOccurs?: number;
     maxOccurs?: string;
+    use?: "required" | "optional" | "prohibited"
 }
 
 export interface SchemaClass {

--- a/packages/xmldom-decorators-cli/src/schemascanner.ts
+++ b/packages/xmldom-decorators-cli/src/schemascanner.ts
@@ -509,7 +509,8 @@ class SchemaClassVisitor extends SchemaVisitor {
             super.visitAttribute(attribute);
         } else {
             const top = this.typeStack[this.typeStack.length - 1];
-            let attributeType: SchemaClass| undefined;
+            let attributeType: SchemaClass | undefined;
+            const useType = attribute.use
             while (true) {
                 if (attribute.type) {
                     attributeType = this.mapper.getSchemaClassByQName(attribute.type);
@@ -569,6 +570,7 @@ class SchemaClassVisitor extends SchemaVisitor {
                 name: attribute.name || "",
                 javaScriptName: getMemberName(attribute.name) || "",
                 type: attributeType,
+                use: useType,
                 xmlType: "attribute",
                 namespaceUri: this.schema ? (this.schema.targetNamespace || null) : null,
             });

--- a/packages/xmldom-decorators-cli/src/xsdschema.ts
+++ b/packages/xmldom-decorators-cli/src/xsdschema.ts
@@ -213,7 +213,7 @@ export class Attribute {
     ref?: QName;
 
     @XMLAttribute()
-    use?: string;
+    use?: "required" | "optional" | "prohibited"
 
     @XMLElement({types:[{name: "simpleType", namespaceUri: "http://www.w3.org/2001/XMLSchema"}]})
     simpleType?: SimpleType;

--- a/packages/xmldom-decorators-cli/test/__snapshots__/attribute-use-optional.test.ts.snap
+++ b/packages/xmldom-decorators-cli/test/__snapshots__/attribute-use-optional.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attribute-use-optional should generate correct code for use=optional attribute: 
+        import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";                                      
+                                                                                                                                               
+      @XMLRoot({name: "exampleElement", namespaceUri: ""})                                                                                     
+      export class exampleElement {                                                                                                            
+          @XMLAttribute()
+          optionalAttribute?: string = undefined;
+      } 1`] = `
+"import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";
+
+@XMLRoot({name: "exampleElement", namespaceUri: ""})
+export class exampleElement {
+    @XMLAttribute()
+    optionalAttribute?: string = undefined;
+
+}
+
+"
+`;

--- a/packages/xmldom-decorators-cli/test/attribute-use-optional.test.ts
+++ b/packages/xmldom-decorators-cli/test/attribute-use-optional.test.ts
@@ -1,0 +1,21 @@
+import { SchemaMapper } from "../src/schemascanner"
+import { formatClasses } from "../src/classformatter"
+
+describe("attribute-use-optional", () => {
+    it("should generate correct code for use=optional attribute", () => {
+        const mapper = new SchemaMapper();
+        mapper.load("test/data/optional-attribute.xsd");
+        
+        const classes = mapper.getClasses();
+        const output = formatClasses(classes);
+
+        expect(output).toMatchSnapshot(`
+        import { XMLRoot, XMLElement, XMLArray, XMLAttribute, XMLText } from "@xinvoice/xmldom-decorators";                                      
+                                                                                                                                               
+      @XMLRoot({name: "exampleElement", namespaceUri: ""})                                                                                     
+      export class exampleElement {                                                                                                            
+          @XMLAttribute()
+          optionalAttribute?: string = undefined;
+      }`)
+    });
+});

--- a/packages/xmldom-decorators-cli/test/data/optional-attribute.xsd
+++ b/packages/xmldom-decorators-cli/test/data/optional-attribute.xsd
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="exampleElement">
+    <xs:complexType>
+      <xs:attribute name="optionalAttribute" use="optional" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/packages/xmldom-decorators-test/package-lock.json
+++ b/packages/xmldom-decorators-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xmldom-decorators-test",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xmldom-decorators-test",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "xmldom-decorators": "file:../xmldom-decorators",

--- a/packages/xmldom-decorators-test/package.json
+++ b/packages/xmldom-decorators-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xinvoice/xmldom-decorators-test",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeScript decorators and (de-)serializer for xmldom",
   "author": "andersnm (forked from by xinvoice)",
   "license": "MIT",

--- a/packages/xmldom-decorators/package-lock.json
+++ b/packages/xmldom-decorators/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xmldom-decorators",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "xmldom-decorators",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "reflect-metadata": "^0.1.12",

--- a/packages/xmldom-decorators/package.json
+++ b/packages/xmldom-decorators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xinvoice/xmldom-decorators",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TypeScript decorators and (de-)serializer for xmldom",
   "author": "andersnm (forked by xinvoice)",
   "license": "MIT",


### PR DESCRIPTION
 This PR improves attribute `use` property functionality by aligning it with the established logic used for the `minOccurs` property, ensuring accurate enforcement of attribute requirements.